### PR TITLE
termite-make: Use bash in shebang for 'exec -a'

### DIFF
--- a/termite-make
+++ b/termite-make
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if test "${TERMITE_CACHE_REFRESHED}" = ""
 then


### PR DESCRIPTION
'exec -a' is only available for bash. On Ubuntu /bin/sh is a symlink to
/bin/dash, which doesn't support 'exec -a'.

Signed-off-by: Haitao Li lihaitao@gmail.com
